### PR TITLE
Create "recent avatars" section & images optimization

### DIFF
--- a/assets/css/_transition.scss
+++ b/assets/css/_transition.scss
@@ -6,3 +6,12 @@
 .page-leave-to {
   opacity: 0;
 }
+
+.simple-enter-active,
+.simple-leave-active {
+  transition: all 0.2s ease-in-out;
+}
+.simple-enter,
+.simple-leave-to {
+  opacity: 0;
+}

--- a/components/Avatars.vue
+++ b/components/Avatars.vue
@@ -1,12 +1,23 @@
 <template>
-  <b-row>
-    <b-col v-if="$fetchState.pending" cols="12">
-      <h5>Please wait...</h5>
+  <b-row class="pt-4">
+    <b-col
+      v-if="$fetchState.pending && firstFetch"
+      cols="12"
+      class="text-center my-5"
+    >
+      <h3 class="blink">Please wait...</h3>
     </b-col>
-    <b-col v-else-if="$fetchState.error" cols="12">
-      <h5>Error!</h5>
-      <p>Unable to load images.</p>
-      <b-button variant="primary" @click="$fetch">Try again</b-button>
+
+    <b-col v-else-if="$fetchState.error" cols="12" class="text-center my-5">
+      <b-row no-gutters>
+        <b-col cols="12" md="6" offset-md="3" class="text-left">
+          <h3>&#9888;&#65039; Error!</h3>
+          <p>Unable to load images.</p>
+          <b-button variant="warning" class="px-5 w-100" @click="$fetch">
+            Try again
+          </b-button>
+        </b-col>
+      </b-row>
     </b-col>
     <b-col v-else cols="12">
       <b-row>

--- a/components/Avatars.vue
+++ b/components/Avatars.vue
@@ -34,7 +34,7 @@
             {{ shortName(a.fields.title) }}
           </p>
           <b-img-lazy
-            :src="a.fields.file.url"
+            :src="a.fields.file.url + '?fm=webp&w=240&h=240&q=90'"
             :alt="a.fields.file.fileName"
             blank-color="#777"
             :rounded="true"

--- a/components/Avatars.vue
+++ b/components/Avatars.vue
@@ -36,6 +36,7 @@
           <b-img-lazy
             :src="a.fields.file.url"
             :alt="a.fields.file.fileName"
+            blank-color="#777"
             :rounded="true"
             fluid
             class="my-2 w-100"

--- a/components/Avatars.vue
+++ b/components/Avatars.vue
@@ -20,7 +20,7 @@
           class="mb-2 mouseOver"
         >
           <p class="mb-0" style="max-height: 24px">
-            {{ shortName(filenameOnly(a.fields.file.fileName)) }}
+            {{ shortName(a.fields.title) }}
           </p>
           <b-img-lazy
             :src="a.fields.file.url"

--- a/components/Avatars.vue
+++ b/components/Avatars.vue
@@ -35,6 +35,7 @@
           </p>
           <b-img-lazy
             :src="a.fields.file.url"
+            :alt="a.fields.file.fileName"
             :rounded="true"
             fluid
             class="my-2 w-100"

--- a/components/Avatars.vue
+++ b/components/Avatars.vue
@@ -21,6 +21,10 @@
     </b-col>
     <b-col v-else cols="12">
       <b-row>
+        <b-col cols="12">
+          <h3>Recently added avatars</h3>
+        </b-col>
+
         <b-col
           v-for="(a, i) in myAssets"
           :key="i"

--- a/components/Avatars.vue
+++ b/components/Avatars.vue
@@ -19,6 +19,7 @@
         </b-col>
       </b-row>
     </b-col>
+
     <b-col v-else cols="12">
       <b-row>
         <b-col cols="12">

--- a/components/KofiButton.vue
+++ b/components/KofiButton.vue
@@ -1,0 +1,22 @@
+<template>
+  <b-link href="https://ko-fi.com/anonymousx86" target="_blank" rel="noopener">
+    <b-img-lazy
+      src="https://uploads-ssl.webflow.com/5c14e387dab576fe667689cf/5cbed8a4ae2b88347c06c923_BuyMeACoffee_blue.png"
+      alt=""
+      height="34"
+      blank-height="34"
+      blank-width="175"
+      blank-color="#29abe0"
+      :rounded="true"
+    />
+  </b-link>
+</template>
+
+<script>
+// noinspection JSUnusedGlobalSymbols
+export default {
+  name: "KofiButton",
+}
+</script>
+
+<style scoped></style>

--- a/components/MyFooter.vue
+++ b/components/MyFooter.vue
@@ -2,16 +2,7 @@
   <footer class="mt-4">
     <b-row no-gutters class="pb-5 pt-3 mx-5 border-top">
       <b-col>
-        <a href="https://ko-fi.com/O5O542WQX" target="_blank" rel="noopener">
-          <b-img
-            height="36"
-            style="border: 0; height: 36px"
-            src="https://cdn.ko-fi.com/cdn/kofi1.png?v=2"
-            alt="Buy Me a Coffee at ko-fi.com"
-            class="d-inline"
-            fluid
-          />
-        </a>
+        <KofiButton />
       </b-col>
       <b-col>
         <p class="text-right text-muted">

--- a/components/MyFooter.vue
+++ b/components/MyFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer>
+  <footer class="mt-4">
     <b-row no-gutters class="pb-5 pt-3 mx-5 border-top">
       <b-col>
         <a href="https://ko-fi.com/O5O542WQX" target="_blank" rel="noopener">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,7 @@
   <b-row no-gutters>
     <b-col cols="12">
       <h1>Avatar database</h1>
-      <h5 class="border-left pl-3">A lot of avatars, free to use</h5>
+      <p class="border-left pl-3 h5">A lot of avatars, free to use</p>
       <p>This is currently empty homepage, everything will be added soon.</p>
     </b-col>
     <b-col cols="12">


### PR DESCRIPTION
- Now in `Avatars.vue` there are only 6, recently added avatars.

- Served images are 90% quality `.webp` files, with maximum sizes 240x240 px.

- Supporting button is now component.

- Added universal transition (named "simple").

- Avatars now have `alt` attribute.

- Text above avatars is now their display name, not file name.

- A few cosmetic changes, like spacing in code and wider margins.